### PR TITLE
fix: make lint ignore `dist/`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import pluginTs from "typescript-eslint";
 
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { ignores: ["dist/"] },
   { languageOptions: { globals: globals.node } },
   pluginJs.configs.recommended,
   ...pluginTs.configs.recommended,


### PR DESCRIPTION
Note: The `ignores` is on a separate block to make it global: <https://eslint.org/docs/latest/use/configure/configuration-files#globally-ignoring-files-with-ignores>.
