### PR TITLE
fix(auth): correctly parse `AUTH_SKIP` environment variable

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,23 @@ function getOption(
   return env;
 }
 
+/**
+ * Parse a boolean-like environment variable.
+ * Returns `true` for 1/true/yes/y, `false` for 0/false/no/n, and
+ * `undefined` if the variable is not set or unrecognized.
+ */
+function getBooleanOption(
+  envName: string,
+  required: boolean = true,
+): boolean | undefined {
+  const val = getOption(envName, required);
+  if (val === undefined) return undefined;
+  const v = val.trim().toLowerCase();
+  if (["1", "true", "yes", "y"].includes(v)) return true;
+  if (["0", "false", "no", "n"].includes(v)) return false;
+  return undefined;
+}
+
 // Pass --options via CLI arguments in command to enable these options.
 const options: AppOptions = {
   // Launching lots of services on the server,
@@ -49,14 +66,7 @@ const options: AppOptions = {
   // mongoUri: getOption("MONGO_URI")!,
   authDiscoveryURL: getOption("AUTH_DISCOVERY_URL")!,
   authClientID: getOption("AUTH_CLIENT_ID")!,
-  authSkip: (() => {
-    const opt = getOption("AUTH_SKIP", false);
-    if (opt !== undefined) {
-      return Boolean(opt);
-    } else {
-      return undefined;
-    }
-  })(),
+  authSkip: getBooleanOption("AUTH_SKIP", false),
 };
 
 // Support Typebox


### PR DESCRIPTION
Fix parsing of `AUTH_SKIP` so common boolean-like values are recognized (1/0, true/false, yes/no). Adds a small `getBooleanOption` helper and uses it to populate `authSkip` in `app.ts`.