### PR TITLE
build(deps): configure dependabot

### DIFF
--- a/.github/.dependabot
+++ b/.github/.dependabot
@@ -21,7 +21,7 @@ updates:
   - package-ecosystem: "yarn"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "build"
       prefix-development: "chore"


### PR DESCRIPTION
The interval is set to be weekly, but it could also be daily or monthly.

For commit message, bumping non-dev deps use "build([scope]): ..." while bumping dev deps use "chore([scope]): ...".

Fixes #65.