### PR TITLE
ci: deduplicate workflow runs by PR-first then SHA; add concurrency and branch filter for push

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,8 +12,9 @@ on:
 #   cancel previous runs and only the latest is kept.
 # - For direct pushes: fall back to deduplicating by commit SHA so identical
 #   commits don't trigger multiple concurrent workflows.
+# - Include the `github.workflow` name in the group to avoid cross-workflow collisions.
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
   cancel-in-progress: true
 
 # Minimal file-level permissions for checks: read repository contents for linting/tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,8 +12,9 @@ on:
 #   cancel previous runs and only the latest is kept.
 # - For direct pushes: fall back to deduplicating by commit SHA so identical
 #   commits don't trigger multiple concurrent workflows.
+# - Include the `github.workflow` name in the group to avoid cross-workflow collisions.
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
   cancel-in-progress: true
 
 # Minimize permissions for Docker CI; only allow read access to repo contents


### PR DESCRIPTION
First, for push events, only pushes to the main branch triggers workflow.

Second, for a PR, only ever the latest commit is checked (for when you push commits quickly to a PR, then this cancels the run for the previous commits). Otherwise, a non-PR commit is only ever has one instance of a workflow running.