### PR TITLE
fix: create named mongo db test container

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,9 +74,13 @@ jobs:
         with:
           node-version: 24
 
+      - name: Remove existing MongoDB container
+        run: docker rm -f mongodb-actions || true
+
       - uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: 7
+          mongodb-container-name: mongodb-actions
 
       - run: |
           corepack enable


### PR DESCRIPTION
Line 77-78 — Added a step that force-removes any existing container named mongodb-actions before the MongoDB action runs (|| true ensures the step doesn't fail if the container doesn't exist).

Line 83 — Added mongodb-container-name: mongodb-actions to the supercharge/mongodb-github-action step so the container is created with the explicit name mongodb-actions.